### PR TITLE
Option to show/hide streak

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,7 @@
                 <form id = "options-form">
                     <p><input type="checkbox" name="furigana"> Show furigana above kanji</p>
                     <p><input type="checkbox" name="emoji"> Show emojis above conjugation types</p>
+                    <p><input type="checkbox" name="streak"> Show current/max streak</p>
                     <hr>
                     <div id="verbs-h3-container">
                         <input type="checkbox" name="verb">

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 // would be less work to just wait x rounds and immeditely show what you missed, without updating any weights.
 "use strict";
 import {bind, isJapanese } from 'wanakana'
-import {optionRemoveFunctions, showFurigana, showEmojis} from "./optionfunctions.js";
+import {optionRemoveFunctions, showFurigana, showEmojis, showStreak} from "./optionfunctions.js";
 import {wordData} from "./worddata.js";
 
 let isTouch = (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0));
@@ -23,6 +23,7 @@ function removeIrrelevantSettingsMaxScore(settings) {
   
   delete coolSettings.furigana;
   delete coolSettings.emoji;
+  delete coolSettings.streak;
   return coolSettings;
 }
 
@@ -1061,6 +1062,7 @@ function optionsMenuInit() {
 function applySettings(settings, completeWordList) {
   showFurigana(settings.furigana);
   showEmojis(settings.emoji);
+  showStreak(settings.streak);
 
   let currentWordList = createArrayOfArrays(completeWordList.length);
 
@@ -1271,7 +1273,7 @@ class ConjugationApp {
     let newMaxScoreSettings = {};
     for (let input of Array.from(inputs)) {
       this.state.settings[input.name] = input.checked;
-      if (input.offsetWidth > 0 && input.offsetHeight > 0 && input.name != "furigana" && input.name != "emoji") {
+      if (input.offsetWidth > 0 && input.offsetHeight > 0 && input.name != "furigana" && input.name != "emoji" && input.name != "streak") {
         newMaxScoreSettings[input.name] = input.checked;
       }
     }

--- a/src/optionfunctions.js
+++ b/src/optionfunctions.js
@@ -104,3 +104,7 @@ export const showFurigana = function(show) {
 export const showEmojis = function(show) {
     document.getElementById("conjugation-inquery-text").className = show ? "" : "hide-emojis";
 }
+
+export const showStreak = function(show) {
+    document.getElementById("streak-container").className = show ? "" : "hide-streak";
+}

--- a/src/style.css
+++ b/src/style.css
@@ -338,7 +338,7 @@ h2 {
     margin-bottom: 0;
 }
 
-.hide-furigana rt, .display-none, .hide-emojis .inquery-emoji {
+.hide-furigana rt, .display-none, .hide-emojis .inquery-emoji, .hide-streak {
     display: none;
 }
 


### PR DESCRIPTION
Add an option to hide the current and max streak counter.  I haven't touched the scoring logic itself, so the streak data will still be tallied even if its display in the UI is hidden.