### PR TITLE
Conditionally load new word after visiting settings. Added labels to form fields.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -59,91 +59,89 @@
             </div>
             <div id="options-view">
                 <h2>Options</h2>
-                <form id = "options-form">
-                    <p><input type="checkbox" name="furigana"> Show furigana above kanji</p>
-                    <p><input type="checkbox" name="emoji"> Show emojis above conjugation types</p>
-                    <p><input type="checkbox" name="streak"> Show current/max streak</p>
+                <form id="options-form">
+                    <p><input id="furigana-checkbox"type="checkbox" name="furigana"><label for="furigana-checkbox">Show furigana above kanji</label></p>
+                    <p><input id="emoji-checkbox" type="checkbox" name="emoji"><label for="emoji-checkbox">Show emojis above conjugation types</label></p>
+                    <p><input id="streak-checkbox" type="checkbox" name="streak"><label for="streak-checkbox">Show current/max streak</label></p>
                     <hr>
                     <div id="verbs-h3-container">
-                        <input type="checkbox" name="verb">
-                        <h3>Verbs</h3>
+                        <input id="verb-checkbox" type="checkbox" name="verb"><label for="verb-checkbox"><h3>Verbs</h3></label>
                         <span id="top-must-choose" class="must-choose-one-text display-none">*Must choose at least 1 option from this category</span>
                     </div>
                     <div class="options-indent" id="verb-options-container">
                         <table style="width:100%" class="options-group">
                             <tr>
-                                <td><input type="checkbox" name="verbu"> う-verbs</td>
+                                <td><input id="verbu-checkbox" type="checkbox" name="verbu"><label for="verbu-checkbox">う-verbs</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input type="checkbox" name="verbru"> る-verbs</td></tr>
-                            <tr><td><input type="checkbox" name="verbirregular"> Irregular verbs</td></tr>
+                            <tr><td><input id="verbru-checkbox" type="checkbox" name="verbru"><label for="verbru-checkbox">る-verbs</label></td></tr>
+                            <tr><td><input id="verbirregular-checkbox" type="checkbox" name="verbirregular"><label for="verbirregular-checkbox">Irregular verbs</label></td></tr>
                         </table>
                         <hr>
                         <table style="width:100%" class="options-group" id="verb-tense-group">
                             <tr>
-                                <td><input type="checkbox" name="verbpresent" class="verb-uses-affirmative-polite"> Present tense</td>
+                                <td><input id="verbpresent-checkbox" type="checkbox" name="verbpresent" class="verb-uses-affirmative-polite"><label for="verbpresent-checkbox">Present tense</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input type="checkbox" name="verbpast" class="verb-uses-affirmative-polite"> Past tense</td></tr>
-                            <tr><td><input type="checkbox" name="verbte"> て-form</td></tr>
+                            <tr><td><input id="verbpast-checkbox" type="checkbox" name="verbpast" class="verb-uses-affirmative-polite"><label for="verbpast-checkbox">Past tense</label></td></tr>
+                            <tr><td><input id="verbte-checkbox" type="checkbox" name="verbte"><label for="verbte-checkbox">て-form</label></td></tr>
                         </table>
                         <div id="verb-affirmative-polite-container">
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
-                                    <td><input type="checkbox" name="verbaffirmative"> Affirmative</td>
+                                    <td><input id="verbaffirmative-checkbox" type="checkbox" name="verbaffirmative"><label for="verbaffirmative-checkbox">Affirmative</label></td>
                                     <td rowspan="2"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                                 </tr>
-                                <tr><td><input type="checkbox" name="verbnegative"> Negative</td></tr>
+                                <tr><td><input id="verbnegative-checkbox" type="checkbox" name="verbnegative"><label for="verbnegative-checkbox">Negative</label></td></tr>
                             </table>
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
-                                    <td><input type="checkbox" name="verbplain"> Plain</td>
+                                    <td><input id="verbplain-checkbox" type="checkbox" name="verbplain"><label for="verbplain-checkbox">Plain</label></td>
                                     <td rowspan="2"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                                 </tr>
-                                <tr><td><input type="checkbox" name="verbpolite"> Polite</td></tr>
+                                <tr><td><input id="verbpolite-checkbox" type="checkbox" name="verbpolite"><label for="verbpolite-checkbox">Polite</label></td></tr>
                             </table>
                         </div>
                     </div>
                     <div id="adjectives-h3-container">
-                        <input type="checkbox" name="adjective">
-                        <h3>Adjectives</h3>
+                        <input id="adjectives-checkbox" type="checkbox" name="adjective"><label for="adjectives-checkbox"><h3>Adjectives</h3></label>
                     </div>
                     <div class="options-indent" id="adjective-options-container">
                         <table style="width:100%" class="options-group" id="adjective-type-group">
                             <tr>
-                                <td><input type="checkbox" name="adjectivei"> い-adjectives</td>
+                                <td><input id="adjectivei-checkbox" type="checkbox" name="adjectivei"><label for="adjectivei-checkbox">い-adjectives</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input type="checkbox" name="adjectivena"> な-adjectives</td></tr>
-                            <tr><td><input type="checkbox" name="adjectiveirregular"> Irregular adjectives</td></tr>
+                            <tr><td><input id="adjectivena-checkbox" type="checkbox" name="adjectivena"><label for="adjectivena-checkbox">な-adjectives</label></td></tr>
+                            <tr><td><input id="adjectiveirregular-checkbox" type="checkbox" name="adjectiveirregular"><label for="adjectiveirregular-checkbox">Irregular adjectives</label></td></tr>
                         </table>
                         <hr>
                         <table style="width:100%" class="options-group" id="adjective-tense-group">
                             <tr>
-                                <td><input type="checkbox" name="adjectivepresent" class="adjective-uses-affirmative-polite"> Present tense</td>
+                                <td><input id="adjectivepresent-checkbox" type="checkbox" name="adjectivepresent" class="adjective-uses-affirmative-polite"><label for="adjectivepresent-checkbox">Present tense</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input type="checkbox" name="adjectivepast" class="adjective-uses-affirmative-polite"> Past tense</td></tr>
-                            <tr><td><input type="checkbox" name="adjectiveadverb"> Adverb</td></tr>
+                            <tr><td><input id="adjectivepast-checkbox" type="checkbox" name="adjectivepast" class="adjective-uses-affirmative-polite"><label for="adjectivepast-checkbox">Past tense</label></td></tr>
+                            <tr><td><input id="adjectiveadverb-checkbox" type="checkbox" name="adjectiveadverb"><label for="adjectiveadverb-checkbox">Adverb</td></tr>
                         </table>
                         <div id="adjective-affirmative-polite-container">
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
-                                    <td><input type="checkbox" name="adjectiveaffirmative"> Affirmative</td>
+                                    <td><input id="adjectiveaffirmative-checkbox" type="checkbox" name="adjectiveaffirmative"><label for="adjectiveaffirmative-checkbox">Affirmative</label></td>
                                     <td rowspan="2"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                                 </tr>
-                                <tr><td><input type="checkbox" name="adjectivenegative"> Negative</td></tr>
+                                <tr><td><input id="adjectivenegative-checkbox" type="checkbox" name="adjectivenegative"><label for="adjectivenegative-checkbox">Negative</label></td></tr>
                             </table>
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
-                                    <td><input type="checkbox" name="adjectiveplain"> Plain</td>
+                                    <td><input id="adjectiveplain-checkbox" type="checkbox" name="adjectiveplain"><label for="adjectiveplain-checkbox">Plain</label></td>
                                     <td rowspan="2"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                                 </tr>
-                                <tr><td><input type="checkbox" name="adjectivepolite"> Polite</td></tr>
+                                <tr><td><input id="adjectivepolite-checkbox" type="checkbox" name="adjectivepolite"><label for="adjectivepolite-checkbox">Polite</label></td></tr>
                             </table>
                         </div>
                     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -820,7 +820,7 @@ function addToScore(amount = 1, maxScoreObjects, maxScoreIndex) {
     max.textContent = newAmount;
     if (!document.getElementById("max-streak").classList.contains("display-none")) {
       max.classList.add("grow-animation");
-    }
+    }  
 
     maxScoreObjects[maxScoreIndex].score = newAmount;
     localStorage.setItem("maxScoreObjects", JSON.stringify(maxScoreObjects));
@@ -828,8 +828,8 @@ function addToScore(amount = 1, maxScoreObjects, maxScoreIndex) {
 
   current.textContent = parseInt(current.textContent) + amount;
   if (!document.getElementById("current-streak").classList.contains("display-none")) {
-    current.classList.add("grow-animation");
-  }
+      current.classList.add("grow-animation");
+    }  
 }
 
 function typeToWordBoxColor(type) {
@@ -1155,27 +1155,6 @@ class ConjugationApp {
     });
 
     optionsMenuInit();
-
-    // need to define this here so the event handler can be removed from within the function and still reference this
-    let onAcceptIncorrectKey = function(e) {
-      let keyCode = (e.keyCode ? e.keyCode : e.which);
-      if (keyCode == '13') {
-        document.removeEventListener("keydown", this.onAcceptIncorrectKeyHandler);
-        document.removeEventListener("touchend", this.onAcceptIncorrectTouchHandler);
-        this.resetMainView();
-      }
-    }
-
-    let onAcceptIncorrectTouch = function(e) {
-      if (e.target != document.getElementById("options-button")) {
-        document.removeEventListener("keydown", this.onAcceptIncorrectKeyHandler);
-        document.removeEventListener("touchend", this.onAcceptIncorrectTouchHandler);
-        this.resetMainView();
-      }
-    }
-
-    this.onAcceptIncorrectKeyHandler = onAcceptIncorrectKey.bind(this);
-    this.onAcceptIncorrectTouchHandler = onAcceptIncorrectTouch.bind(this);
   }
 
   resetMainView() {
@@ -1186,12 +1165,33 @@ class ConjugationApp {
     document.getElementById("press-any-key-text").style.display = "none";
     document.getElementById("status-box").style.display = "none";
 
-    if (this.state.currentStreakReset) {
+    if (this.state.currentStreak0OnReset) {
       document.getElementById("current-streak-text").textContent = "0";
-      this.state.currentStreakReset = false;
+      this.state.currentStreak0OnReset = false;
     }
 
-    this.state.currentWord = loadNewWord(this.state.currentWordList);
+    if (this.state.loadWordOnReset) {
+      this.state.currentWord = loadNewWord(this.state.currentWordList);
+      this.state.loadWordOnReset = false;
+    }
+    
+  }
+
+  onResultsViewKeyDown(e) {
+    let keyCode = (e.keyCode ? e.keyCode : e.which);
+    if (keyCode == '13') {
+      document.removeEventListener("keydown", this.onResultsViewKeyDown);
+      document.removeEventListener("touchend", this.onResultsViewTouchEnd);
+      this.resetMainView();
+    }
+  }
+
+  onResultsViewTouchEnd(e) {
+    if (e.target != document.getElementById("options-button")) {
+      document.removeEventListener("keydown", this.onResultsViewKeyDown);
+      document.removeEventListener("touchend", this.onResultsViewTouchEnd);
+      this.resetMainView();
+    }
   }
 
   inputKeyPress(e) {
@@ -1199,7 +1199,6 @@ class ConjugationApp {
     if (keyCode == '13') {
       let inputElt = document.getElementsByTagName("input")[0];
       e.stopPropagation();
-
       
       let inputValue = inputElt.value;
       const finalChar = inputValue[inputValue.length - 1];
@@ -1231,23 +1230,24 @@ class ConjugationApp {
 
       if (inputWasCorrect) {
         addToScore(1, this.state.maxScoreObjects, this.state.maxScoreIndex);
-        this.state.currentStreakReset = false;
+        this.state.currentStreak0OnReset = false;
       } else {
-        this.state.currentStreakReset = true;
+        this.state.currentStreak0OnReset = true;
       }
+      this.state.loadWordOnReset = true;
 
       document.getElementsByTagName("input")[0].disabled = true;
       document.getElementById("press-any-key-text").style.display = "table-cell";
-      document.addEventListener("keydown", this.onAcceptIncorrectKeyHandler);
-      document.addEventListener("touchend", this.onAcceptIncorrectTouchHandler);
+      document.addEventListener("keydown", this.onResultsViewKeyDown.bind(this));
+      document.addEventListener("touchend", this.onResultsViewTouchEnd.bind(this));
 
       inputElt.value = "";
     }
   }
 
   settingsButtonClicked(e) {
-    document.removeEventListener("keydown", this.onAcceptIncorrectKeyHandler);
-    document.removeEventListener("touchend", this.onAcceptIncorrectTouchHandler);
+    document.removeEventListener("keydown", this.onResultsViewKeyDown);
+    document.removeEventListener("touchend", this.onResultsViewTouchEnd);
 
     let inputs = document.getElementById("options-form").querySelectorAll('[type="checkbox"]');
     for (let input of Array.from(inputs)) {
@@ -1265,9 +1265,7 @@ class ConjugationApp {
 
     document.getElementById("main-view").style.display = "none";
     document.getElementById("options-view").style.display = "block";
-    document.getElementById("donation-seciton").style.display = "block";
-
-    this.state.currentStreakReset = true;
+    document.getElementById("donation-seciton").style.display = "block";   
   }
 
   backButtonClicked(e) {
@@ -1290,14 +1288,18 @@ class ConjugationApp {
       settingsIndex = this.state.maxScoreObjects.length - 1;
     }
 
-    localStorage.setItem("maxScoreIndex", settingsIndex);
-    this.state.maxScoreIndex = settingsIndex;
+    if (settingsIndex !== this.state.maxScoreIndex) {
+      localStorage.setItem("maxScoreIndex", settingsIndex);
+      this.state.maxScoreIndex = settingsIndex;
+      this.state.currentStreak0OnReset = true;
+      this.state.loadWordOnReset = true;
+    }
+
     document.getElementById("max-streak-text").textContent = this.state.maxScoreObjects[this.state.maxScoreIndex].score;
 
     this.state.currentWordList = applySettings(this.state.settings, this.state.completeWordList);
     addValueToProbabilities(this.state.currentWordList, 1, "=");
     this.resetMainView();
-    // if clicked settings from correct/neutral state, need to load new word immediately without adding to score
 
     document.getElementById("main-view").style.display = "block";
     document.getElementById("options-view").style.display = "none";
@@ -1318,7 +1320,7 @@ class ConjugationApp {
       this.state.maxScoreObjects = [new maxScoreObject(0, removeIrrelevantSettingsMaxScore(this.state.settings))]; 
       localStorage.setItem("maxScoreObjects", JSON.stringify(this.state.maxScoreObjects));
     } else {
-      this.state.maxScoreIndex = localStorage.getItem("maxScoreIndex");
+      this.state.maxScoreIndex = parseInt(localStorage.getItem("maxScoreIndex"));
       this.state.settings = Object.assign(defaultSettings(), JSON.parse(localStorage.getItem("settings")));
       this.state.maxScoreObjects = JSON.parse(localStorage.getItem("maxScoreObjects"));
     }
@@ -1327,7 +1329,8 @@ class ConjugationApp {
     this.state.currentWord = loadNewWord(this.state.currentWordList);
     this.state.wordsRecentlySeen = [];
 
-    this.state.currentStreakReset = false;
+    this.state.currentStreak0OnReset = false;
+    this.state.loadWordOnReset = false;
 
     document.getElementById("max-streak-text").textContent = this.state.maxScoreObjects[this.state.maxScoreIndex].score;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -322,6 +322,10 @@ h2 {
     height: 0.6rem;
 }
 
+#options-form label {
+    padding-left: 0.25rem;
+}
+
 .options-indent {
     padding-left: 1.36rem;
 }


### PR DESCRIPTION
- Previously if a user went to settings and didn't change anything, a new word would still be loaded when returning to the main page. To fix this, I added state.loadWordOnReset. This is only set to true on the settings page if a user changes a setting that updates the word pool.
- Refactored onAcceptIncorrectKey/onAcceptIncorrectTouch, renaming them to onResultsViewKeyDown/onResultsViewTouchEnd
- Added `<label>` tags to form fields.
