### PR TITLE
Setting to hide English translation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,11 +28,8 @@
                     <div id="verb-container">
                         <div id="verb-box">
                             <p id="verb-text"></p>
-                            <br>
-                            <p id="definition"></p>
-                            <br>
+                            <p id="translation"></p>
                             <p id="verb-type"></p>
-                            <br>
                         </div>
                     </div>
                     <div id="conjugation-inquery-container">
@@ -60,9 +57,12 @@
             <div id="options-view">
                 <h2>Options</h2>
                 <form id="options-form">
-                    <p><input id="furigana-checkbox"type="checkbox" name="furigana"><label for="furigana-checkbox">Show furigana above kanji</label></p>
-                    <p><input id="emoji-checkbox" type="checkbox" name="emoji"><label for="emoji-checkbox">Show emojis above conjugation types</label></p>
-                    <p><input id="streak-checkbox" type="checkbox" name="streak"><label for="streak-checkbox">Show current/max streak</label></p>
+                    <div id="non-conjugation-settings">
+                        <p><input id="furigana-checkbox"type="checkbox" name="furigana"><label for="furigana-checkbox">Show furigana above kanji</label></p>
+                        <p><input id="translation-checkbox" type="checkbox" name="translation"><label for="translation-checkbox">Show English translations</label></p>
+                        <p><input id="emoji-checkbox" type="checkbox" name="emoji"><label for="emoji-checkbox">Show emojis above conjugation types</label></p>
+                        <p><input id="streak-checkbox" type="checkbox" name="streak"><label for="streak-checkbox">Show current/max streak</label></p>
+                    </div>
                     <hr>
                     <div id="verbs-h3-container">
                         <input id="verb-checkbox" type="checkbox" name="verb"><label for="verb-checkbox"><h3>Verbs</h3></label>

--- a/src/optionfunctions.js
+++ b/src/optionfunctions.js
@@ -114,3 +114,7 @@ export const showStreak = function(show) {
         }
     });
 }
+
+export const showTranslation = function(show) {
+    document.getElementById("translation").className = show ? "" : "display-none";
+}

--- a/src/style.css
+++ b/src/style.css
@@ -86,7 +86,6 @@ p {
 }
 
 #verb-box p {
-    display: inline-block;
     margin-left: 1.18rem;
     margin-right: 1.18rem;
 }
@@ -98,10 +97,10 @@ p {
 #verb-text {
     font-size: 2.2rem;
     margin-top: 0;
-    margin-bottom: -1rem;
+    margin-bottom: -0.5rem;
 }
 
-#definition {
+#translation {
     font-size: 0.8rem;
     margin-top: 0;
     margin-bottom: 0.18rem;
@@ -110,7 +109,8 @@ p {
 #verb-type {
     line-height: 1;
     font-size: 0.8rem;
-    margin: 0;
+    margin-top: 0.6rem;
+    margin-bottom: 0.15rem;
 }
 
 #conjugation-inquery-text {


### PR DESCRIPTION
Fixes #14

Also:
- Renamed the "definition" element to "translation"
- Refactored how the conjugation settings are filtered out when saving to local storage