### PR TITLE
Always show translations in results view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1449,6 +1449,8 @@ class ConjugationApp {
 	}
 
 	resetMainView() {
+		applyNonConjugationSettings(this.state.settings);
+
 		document.getElementsByTagName("input")[0].disabled = false;
 		document.getElementsByTagName("input")[0].value = "";
 		document
@@ -1516,6 +1518,8 @@ class ConjugationApp {
 			}
 
 			inputElt.blur();
+			showFurigana(true);
+			showTranslation(true);
 			updateStatusBoxes(this.state.currentWord, inputValue);
 
 			// update probabilities before next word is chosen so don't choose same word

--- a/src/main.js
+++ b/src/main.js
@@ -1518,7 +1518,6 @@ class ConjugationApp {
 			}
 
 			inputElt.blur();
-			showFurigana(true);
 			showTranslation(true);
 			updateStatusBoxes(this.state.currentWord, inputValue);
 

--- a/src/optionfunctions.js
+++ b/src/optionfunctions.js
@@ -126,7 +126,10 @@ export const showStreak = function (show) {
 };
 
 export const showTranslation = function (show) {
-	document.getElementById("translation").className = show
-		? ""
-		: "display-none";
+	const el = document.getElementById("translation");
+	if (show) {
+		el.classList.remove("transparent");
+	} else {
+		el.classList.add("transparent");
+	}
 };

--- a/src/style.css
+++ b/src/style.css
@@ -353,11 +353,11 @@ h2 {
 	margin-bottom: 0;
 }
 
-.hide-furigana rt,
 .transparent {
 	opacity: 0;
 }
 
+.hide-furigana rt,
 .display-none,
 .hide-emojis .inquery-emoji {
 	display: none;

--- a/src/style.css
+++ b/src/style.css
@@ -354,6 +354,10 @@ h2 {
 }
 
 .hide-furigana rt,
+.transparent {
+	opacity: 0;
+}
+
 .display-none,
 .hide-emojis .inquery-emoji {
 	display: none;


### PR DESCRIPTION
Partially addresses #17.

I only discovered this app recently and have really enjoyed using it. I also would like to also memorize vocabulary this way, so I would like the option to always show the translations after submission to check whether I was correct or not.

If a user has translations to show, there should be no changes to the user experience.

If a user has translations set to hide, during the quiz they still won't be able to see it, but only in the results screen will they see it. This should have no net negative to the user's experience, aside from maybe some slightly increased height.

You can test out the changes live here: https://vince.id.au/japanese-conjugation/