### PR TITLE
New option to show English translation only after answering + general code cleanup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+worddata.js

--- a/src/index.html
+++ b/src/index.html
@@ -58,14 +58,20 @@
                 <h2>Options</h2>
                 <form id="options-form">
                     <div id="non-conjugation-settings">
-                        <p><input id="furigana-checkbox"type="checkbox" name="furigana"><label for="furigana-checkbox">Show furigana above kanji</label></p>
-                        <p><input id="translation-checkbox" type="checkbox" name="translation"><label for="translation-checkbox">Show English translations</label></p>
-                        <p><input id="emoji-checkbox" type="checkbox" name="emoji"><label for="emoji-checkbox">Show emojis above conjugation types</label></p>
-                        <p><input id="streak-checkbox" type="checkbox" name="streak"><label for="streak-checkbox">Show current/max streak</label></p>
+                        <div class="option-row"><input id="furigana-checkbox"type="checkbox" name="furigana"><label for="furigana-checkbox">Show furigana above kanji</label></div>
+                        <div class="option-row">
+                            <div class="sub-option-row"><input id="translation-checkbox" type="checkbox" name="translation"><label for="translation-checkbox">Show English translations</label></div>
+                            <div id="translation-sub-options" class="option-row options-indent sub-options">
+                                <div class="sub-option-row"><input id="translation-always-radio" type="radio" name="translationTiming" value="always"><label for="translation-always-radio">always</label></div>
+                                <div class="sub-option-row"><input id="translation-after-radio" type="radio" name="translationTiming" value="after"><label for="translation-after-radio">only after answering</label></div>
+                            </div>
+                        </div>
+                        <div class="option-row"><input id="emoji-checkbox" type="checkbox" name="emoji"><label for="emoji-checkbox">Show emojis above conjugation types</label></div>
+                        <div class="option-row"><input id="streak-checkbox" type="checkbox" name="streak"><label for="streak-checkbox">Show current/max streak</label></div>
                     </div>
                     <hr>
                     <div id="verbs-h3-container">
-                        <input id="verb-checkbox" type="checkbox" name="verb"><label for="verb-checkbox"><h3>Verbs</h3></label>
+                        <input id="verbs-checkbox" type="checkbox" name="verb"><label for="verbs-checkbox"><h3>Verbs</h3></label>
                         <span id="top-must-choose" class="must-choose-one-text display-none">*Must choose at least 1 option from this category</span>
                     </div>
                     <div class="options-indent" id="verb-options-container">
@@ -80,13 +86,13 @@
                         <hr>
                         <table style="width:100%" class="options-group" id="verb-tense-group">
                             <tr>
-                                <td><input id="verbpresent-checkbox" type="checkbox" name="verbpresent" class="verb-uses-affirmative-polite"><label for="verbpresent-checkbox">Present tense</label></td>
+                                <td><input id="verbpresent-checkbox" type="checkbox" name="verbpresent" class="verb-has-variations"><label for="verbpresent-checkbox">Present tense</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input id="verbpast-checkbox" type="checkbox" name="verbpast" class="verb-uses-affirmative-polite"><label for="verbpast-checkbox">Past tense</label></td></tr>
+                            <tr><td><input id="verbpast-checkbox" type="checkbox" name="verbpast" class="verb-has-variations"><label for="verbpast-checkbox">Past tense</label></td></tr>
                             <tr><td><input id="verbte-checkbox" type="checkbox" name="verbte"><label for="verbte-checkbox">て-form</label></td></tr>
                         </table>
-                        <div id="verb-affirmative-polite-container">
+                        <div id="verb-variations-container">
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
@@ -120,13 +126,13 @@
                         <hr>
                         <table style="width:100%" class="options-group" id="adjective-tense-group">
                             <tr>
-                                <td><input id="adjectivepresent-checkbox" type="checkbox" name="adjectivepresent" class="adjective-uses-affirmative-polite"><label for="adjectivepresent-checkbox">Present tense</label></td>
+                                <td><input id="adjectivepresent-checkbox" type="checkbox" name="adjectivepresent" class="adjective-has-variations"><label for="adjectivepresent-checkbox">Present tense</label></td>
                                 <td rowspan="3"class="must-choose-one-text display-none">*Must choose at least 1 option from this category</td>
                             </tr>
-                            <tr><td><input id="adjectivepast-checkbox" type="checkbox" name="adjectivepast" class="adjective-uses-affirmative-polite"><label for="adjectivepast-checkbox">Past tense</label></td></tr>
+                            <tr><td><input id="adjectivepast-checkbox" type="checkbox" name="adjectivepast" class="adjective-has-variations"><label for="adjectivepast-checkbox">Past tense</label></td></tr>
                             <tr><td><input id="adjectiveadverb-checkbox" type="checkbox" name="adjectiveadverb"><label for="adjectiveadverb-checkbox">Adverb</td></tr>
                         </table>
-                        <div id="adjective-affirmative-polite-container">
+                        <div id="adjective-variations-container">
                             <hr>
                             <table style="width:100%" class="options-group">
                                 <tr>
@@ -151,7 +157,7 @@
                 </form>
             </div>
         </div>
-        <div id="donation-seciton">
+        <div id="donation-section">
             <p class="footer-text">This app's <a href="https://github.com/baileysnyder/japanese-conjugation" target="_blank">source code</a> is available to use under the GPL-3.0 license.</p>
             <p class="footer-text">If you've found this app useful and would like to help support it please consider donating!</p>
             <form action="https://www.paypal.com/donate" method="post" target="_top">

--- a/src/optionfunctions.js
+++ b/src/optionfunctions.js
@@ -19,88 +19,87 @@ function isNotTense(word, s) {
 	return word.conjugation.tense != s;
 }
 
-// would be better to store inquery words as const in separate file
-// when an option is set to true, these filter functions will be used
-// input is a Word from main.js
-// create sub array with all verbs, then run affirmative, polite checks on sub array to avoid checking if verb twice
-export const optionRemoveFunctions = {
-	verb: function (x) {
-		return wordPartOfSpeech(x) != "v";
+// The input to these functions is a "Word" object defined in main.js.
+// If one of these filters is applied to an array of Words,
+// that type of Word will be removed from the array.
+export const questionRemoveFilters = {
+	verb: function (word) {
+		return wordPartOfSpeech(word) != "v";
 	},
 
 	verbs: {
-		verbpresent: function (x) {
-			return isNotTense(x, "Present");
+		verbpresent: function (word) {
+			return isNotTense(word, "Present");
 		},
-		verbpast: function (x) {
-			return isNotTense(x, "Past");
+		verbpast: function (word) {
+			return isNotTense(word, "Past");
 		},
-		verbte: function (x) {
-			return isNotTense(x, "て-form");
-		},
-
-		verbaffirmative: function (x) {
-			return x.conjugation.affirmative !== true;
-		},
-		verbnegative: function (x) {
-			return x.conjugation.affirmative !== false;
+		verbte: function (word) {
+			return isNotTense(word, "て-form");
 		},
 
-		verbplain: function (x) {
-			return x.conjugation.polite !== false;
+		verbaffirmative: function (word) {
+			return word.conjugation.affirmative !== true;
 		},
-		verbpolite: function (x) {
-			return x.conjugation.polite !== true;
+		verbnegative: function (word) {
+			return word.conjugation.affirmative !== false;
 		},
 
-		verbu: function (x) {
-			return x.wordJSON.type != "u";
+		verbplain: function (word) {
+			return word.conjugation.polite !== false;
 		},
-		verbru: function (x) {
-			return x.wordJSON.type != "ru";
+		verbpolite: function (word) {
+			return word.conjugation.polite !== true;
 		},
-		verbirregular: function (x) {
-			return x.wordJSON.type != "irv";
+
+		verbu: function (word) {
+			return word.wordJSON.type != "u";
+		},
+		verbru: function (word) {
+			return word.wordJSON.type != "ru";
+		},
+		verbirregular: function (word) {
+			return word.wordJSON.type != "irv";
 		},
 	},
 
-	adjective: function (x) {
-		return wordPartOfSpeech(x) != "a";
+	adjective: function (word) {
+		return wordPartOfSpeech(word) != "a";
 	},
 
 	adjectives: {
-		adjectivepresent: function (x) {
-			return isNotTense(x, "Present");
+		adjectivepresent: function (word) {
+			return isNotTense(word, "Present");
 		},
-		adjectivepast: function (x) {
-			return isNotTense(x, "Past");
+		adjectivepast: function (word) {
+			return isNotTense(word, "Past");
 		},
-		adjectiveadverb: function (x) {
-			return isNotTense(x, "Adverb");
-		},
-
-		adjectiveaffirmative: function (x) {
-			return x.conjugation.affirmative !== true;
-		},
-		adjectivenegative: function (x) {
-			return x.conjugation.affirmative !== false;
+		adjectiveadverb: function (word) {
+			return isNotTense(word, "Adverb");
 		},
 
-		adjectiveplain: function (x) {
-			return x.conjugation.polite !== false;
+		adjectiveaffirmative: function (word) {
+			return word.conjugation.affirmative !== true;
 		},
-		adjectivepolite: function (x) {
-			return x.conjugation.polite !== true;
+		adjectivenegative: function (word) {
+			return word.conjugation.affirmative !== false;
 		},
 
-		adjectivei: function (x) {
-			return x.wordJSON.type != "i";
+		adjectiveplain: function (word) {
+			return word.conjugation.polite !== false;
 		},
-		adjectivena: function (x) {
-			return x.wordJSON.type != "na";
+		adjectivepolite: function (word) {
+			return word.conjugation.polite !== true;
 		},
-		adjectiveirregular: function (x) {
-			return x.wordJSON.type != "ira";
+
+		adjectivei: function (word) {
+			return word.wordJSON.type != "i";
+		},
+		adjectivena: function (word) {
+			return word.wordJSON.type != "na";
+		},
+		adjectiveirregular: function (word) {
+			return word.wordJSON.type != "ira";
 		},
 	},
 };
@@ -125,8 +124,23 @@ export const showStreak = function (show) {
 	});
 };
 
-export const showTranslation = function (show) {
-	document.getElementById("translation").className = show
-		? ""
-		: "display-none";
+// The translation can be shown never, always, or only after answering.
+// If it's only after answering, we make it transparent before answering
+// so the app height doesn't change between question and answer.
+export const showTranslation = function (showInDom, makeTransparent = false) {
+	let el = document.getElementById("translation");
+
+	// Reset state
+	el.classList.remove("display-none");
+	el.classList.remove("transparent");
+
+	if (!showInDom) {
+		el.classList.add("display-none");
+		return;
+	}
+
+	if (makeTransparent) {
+		el.classList.add("transparent");
+		return;
+	}
 };

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,10 @@ a {
 	color: #ffc439;
 }
 
+input {
+	accent-color: #6e6e6e;
+}
+
 .streak p {
 	margin: 0;
 	margin-bottom: 0;
@@ -306,9 +310,12 @@ h2 {
 	color: var(--whiteTextColor);
 }
 
-#options-form p {
-	text-align: left;
-	margin: 0.18rem;
+#options-form .option-row {
+	margin-bottom: 0.18rem;
+}
+
+#options-form .sub-option-row {
+	margin-bottom: 0.09rem;
 }
 
 #top-must-choose {
@@ -353,6 +360,10 @@ h2 {
 	margin-bottom: 0;
 }
 
+.transparent {
+	opacity: 0;
+}
+
 .hide-furigana rt,
 .display-none,
 .hide-emojis .inquery-emoji {
@@ -370,11 +381,6 @@ hr {
 	margin-bottom: 0.45rem;
 }
 
-#options-form p {
-	margin-left: 0;
-	margin-right: 0;
-}
-
 .footer-text {
 	color: gray;
 	font-size: 0.61rem;
@@ -382,7 +388,7 @@ hr {
 	margin-top: 0.3rem;
 }
 
-#donation-seciton {
+#donation-section {
 	margin: 0.6rem;
 	text-align: center;
 	display: none;


### PR DESCRIPTION
Related issue: #17 

I also:
- Changed the input accent-color to be gray, overriding the browser's default (blue for most browsers)
- Added worddata.js to a new .prettierignore file since when Prettier tries formatting it, it becomes harder to read

All of the other changes should just be refactoring the code so it's easier to understand.