### PR TITLE
Make height smaller on mobile. Added cursor pointer to buttons, checkboxes, radios.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,11 @@ import {
 } from "./settingManagement.js";
 import { wordData } from "./wordData.js";
 import { CONJUGATION_TYPES, PARTS_OF_SPEECH } from "./wordEnums.js";
-import { toggleDisplayNone, createArrayOfArrays } from "./utils.js";
+import {
+	toggleDisplayNone,
+	createArrayOfArrays,
+	toggleBackgroundNone,
+} from "./utils.js";
 
 const isTouch = "ontouchstart" in window || navigator.msMaxTouchPoints > 0;
 document.getElementById("press-any-key-text").textContent = isTouch
@@ -105,7 +109,10 @@ function loadNewWord(wordList) {
 }
 
 function updateCurrentWord(word) {
-	document.getElementById("verb-box").style.background = "none";
+	// Caution: verb-box is controlled using a combination of the background-none class and setting style.background directly.
+	// The background-none class is useful for other CSS selectors to grab onto,
+	// while the style.background is useful for setting variable bg colors.
+	toggleBackgroundNone(document.getElementById("verb-box"), true);
 	// The <rt> element had different padding on different browsers.
 	// Rather than attacking it with CSS, just replace it with a span we have control over.
 	const verbHtml = word.wordJSON.kanji
@@ -1517,6 +1524,7 @@ function updateStatusBoxes(word, entryText) {
 		document.getElementById("verb-box").style.background = typeToWordBoxColor(
 			word.wordJSON.type
 		);
+		toggleBackgroundNone(document.getElementById("verb-box"), false);
 		changeVerbBoxFontColor("white");
 		document.getElementById("verb-type").textContent = wordTypeToDisplayText(
 			word.wordJSON.type
@@ -1600,6 +1608,8 @@ class ConjugationApp {
 
 	loadMainView() {
 		this.state.activeScreen = SCREENS.question;
+		document.getElementById("main-view").classList.add("question-screen");
+		document.getElementById("main-view").classList.remove("results-screen");
 
 		document
 			.getElementById("input-tooltip")
@@ -1641,7 +1651,11 @@ class ConjugationApp {
 	// Handle generic keydown events that aren't targeting a specific element
 	onKeyDown(e) {
 		let keyCode = e.keyCode ? e.keyCode : e.which;
-		if (this.state.activeScreen === SCREENS.results && keyCode == "13") {
+		if (
+			this.state.activeScreen === SCREENS.results &&
+			keyCode == "13" &&
+			document.activeElement.id !== "options-button"
+		) {
 			this.loadMainView();
 		}
 	}
@@ -1660,7 +1674,6 @@ class ConjugationApp {
 		let keyCode = e.keyCode ? e.keyCode : e.which;
 		if (keyCode == "13") {
 			e.stopPropagation();
-			this.state.activeScreen = SCREENS.results;
 
 			const mainInput = document.getElementById("main-text-input");
 			let inputValue = mainInput.value;
@@ -1686,6 +1699,12 @@ class ConjugationApp {
 					.getElementById("input-tooltip")
 					.classList.remove("tooltip-fade-animation");
 			}
+
+			this.state.activeScreen = SCREENS.results;
+			document
+				.getElementById("main-view")
+				.classList.remove("question-screen");
+			document.getElementById("main-view").classList.add("results-screen");
 
 			mainInput.blur();
 			updateStatusBoxes(this.state.currentWord, inputValue);

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,13 @@ input {
 	accent-color: #6e6e6e;
 }
 
+input[type="checkbox"],
+input[type="radio"],
+input[type="checkbox"] + label,
+input[type="radio"] + label {
+	cursor: pointer;
+}
+
 .streak p {
 	margin: 0;
 	margin-bottom: 0;
@@ -288,6 +295,7 @@ button {
 
 button:hover {
 	background: rgb(70, 70, 70);
+	cursor: pointer;
 }
 
 button:disabled {
@@ -383,6 +391,10 @@ h2 {
 	display: none !important;
 }
 
+.background-none {
+	background: none !important;
+}
+
 hr {
 	margin: 0.18rem;
 	border: 0.045rem solid rgb(66, 66, 66);
@@ -443,9 +455,30 @@ hr {
 	font-style: italic;
 	margin-bottom: 0.2rem;
 	color: #6e6e6e;
-	/* border-bottom: 2px solid #424242; */
 	display: flex;
 	align-items: center;
+}
+
+.question-screen #verb-type,
+.results-screen #verb-box.background-none #verb-type {
+	display: none;
+}
+
+.question-screen #status-container {
+	min-height: 0.8rem;
+}
+
+/* On smaller screens, we prevent verb-type and status-container from taking up screen height when they're invisible so on-screen keyboards don't cover up parts of the app while answering.
+On larger screens, we allow verb-type and status-container to always take up screen height so the app stays the same height between the question and results screen. */
+@media screen and (min-height: 820px), screen and (min-width: 510px) {
+	.question-screen #verb-type,
+	.results-screen #verb-box.background-none #verb-type {
+		display: block;
+	}
+
+	.question-screen #status-container {
+		min-height: 4rem;
+	}
 }
 
 @media screen and (min-width: 510px) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,10 @@ export function toggleDisplayNone(element, isDisplayNone) {
 	toggleClassName(element, "display-none", isDisplayNone);
 }
 
+export function toggleBackgroundNone(element, isBackgroundNone) {
+	toggleClassName(element, "background-none", isBackgroundNone);
+}
+
 function toggleClassName(element, className, enabled) {
 	if (enabled) {
 		element.classList.add(className);


### PR DESCRIPTION
This was fixing an issue where on mobile screens the app was too tall, so opening and closing the virtual keyboard would cause the screen to shift around a lot.

I also fixed an issue where on the results screen I wasn't able to tab to the options button and hit enter to select it.